### PR TITLE
Validate lower-bound for profiling frequency

### DIFF
--- a/src/main/java/com/papertrail/profiler/CpuProfile.java
+++ b/src/main/java/com/papertrail/profiler/CpuProfile.java
@@ -193,7 +193,10 @@ public class CpuProfile {
         precision was incorrect. Each time it looked at the clock or slept, it was using millis under the hood.
         */
         if (frequency > 1000) {
-            throw new RuntimeException("frequency must be < 1000");
+            throw new IllegalArgumentException("frequency must be <= 1000");
+        }
+        if (frequency < 1) {
+            throw new IllegalArgumentException("frequency must be > 0");
         }
 
         // TODO: it may make sense to write a custom hash function here

--- a/src/test/java/com/papertrail/profiler/CpuProfileTest.java
+++ b/src/test/java/com/papertrail/profiler/CpuProfileTest.java
@@ -37,6 +37,16 @@ public class CpuProfileTest {
         assertTrue(baos.toString().contains("Thread.sleep"));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testRecord_FrequencyTooHigh() throws Exception {
+        CpuProfile.record(Duration.standardSeconds(1), 1001, Thread.State.TIMED_WAITING);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRecord_FrequencyTooLow() throws Exception {
+        CpuProfile.record(Duration.standardSeconds(1), 0, Thread.State.TIMED_WAITING);
+    }
+
     @Test
     public void testisRunnable() {
         assertTrue(CpuProfile.isRunnable(newElem("foo", "bar")));


### PR DESCRIPTION
When `CpuProfile.record()` is currently passed a negative `frequency` argument, the local variable `periodMillis` equally becomes negative which in turn makes the following loop from the method endless:
````
            while (next.isBefore(Instant.now()) && next.isBefore(end)) {
                nmissed += 1;
                next = next.plus(periodMillis);
            }
````

This PR extends the existing validation for the `frequency` parameter to also check the lower-bound.

While at it, I felt compelled to fix the error message for the upper-bound case and for both bounds consistenly use a more specific/fitting exception type.